### PR TITLE
chore: bump bpmn-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1271,15 +1271,15 @@
       "dev": true
     },
     "bpmn-js": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-7.5.0.tgz",
-      "integrity": "sha512-0ANaE6Bikg1GmkcvO7RK0MQPX+EKYKBc+q7OWk39/16NcCdNZ/4UiRcCr9n0u1VUCIDsSU/jJ79TIZFnV5CNjw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-8.2.0.tgz",
+      "integrity": "sha512-ZfA5h0AtWkG9V3Sa8jg/0NDE6hPjewTm2r0EqFBg6nDFYBoq1kUnEiPO3Z+XyoMkPqTOREcZYetuboRgmZizTw==",
       "dev": true,
       "requires": {
         "bpmn-moddle": "^7.0.4",
         "css.escape": "^1.5.1",
-        "diagram-js": "^6.8.2",
-        "diagram-js-direct-editing": "^1.6.1",
+        "diagram-js": "^7.2.0",
+        "diagram-js-direct-editing": "^1.6.2",
         "ids": "^1.0.0",
         "inherits": "^2.0.4",
         "min-dash": "^3.5.2",
@@ -1289,21 +1289,27 @@
       },
       "dependencies": {
         "diagram-js": {
-          "version": "6.8.2",
-          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-6.8.2.tgz",
-          "integrity": "sha512-5EKYHjW2mmGsn9/jSenSkm8cScK5sO9eETBRQNIIzgZjxBDJn6eX964L2d7/vrAW9SeuijGUsztL9+NUinSsNg==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.2.0.tgz",
+          "integrity": "sha512-K1cJkz/e00oX+wJqaAynonteRvDi/OHP+wgJS3+lulXMUc9vdk7o5m10Vdb60Mb/Z2bsbVRyn7pJmngj/jopEQ==",
           "dev": true,
           "requires": {
             "css.escape": "^1.5.1",
-            "didi": "^4.0.0",
+            "didi": "^5.2.1",
             "hammerjs": "^2.0.1",
-            "inherits": "^2.0.1",
-            "min-dash": "^3.5.0",
-            "min-dom": "^3.1.2",
+            "inherits": "^2.0.4",
+            "min-dash": "^3.5.2",
+            "min-dom": "^3.1.3",
             "object-refs": "^0.3.0",
             "path-intersection": "^2.2.0",
-            "tiny-svg": "^2.2.1"
+            "tiny-svg": "^2.2.2"
           }
+        },
+        "didi": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-5.2.1.tgz",
+          "integrity": "sha512-IKNnajUlD4lWMy/Q9Emkk7H1qnzREgY4UyE3IhmOi/9IKua0JYtYldk928bOdt1yNxN8EiOy1sqtSozEYsmjCg==",
+          "dev": true
         },
         "min-dash": {
           "version": "3.5.2",
@@ -2308,13 +2314,33 @@
       }
     },
     "diagram-js-direct-editing": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.6.1.tgz",
-      "integrity": "sha512-FOW2qp7yT/L3Go/YfBOfnWrV2pc2PPoTSSRIg2nnld8pQDTnMaqKPva9GZEoCtcTJzPV4ctZX52ZdkJ3C7aWaA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.6.2.tgz",
+      "integrity": "sha512-hAiSnt6iETMLHBRsCU+XeATiV7u/rovlAX/l4MnvzW6+VeHqQOn+xFetD6JwxfTHKvT3h9fAQpfMZPOPlRFNlw==",
       "dev": true,
       "requires": {
-        "min-dash": "^3.0.0",
-        "min-dom": "^3.0.0"
+        "min-dash": "^3.5.2",
+        "min-dom": "^3.1.3"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.5.2.tgz",
+          "integrity": "sha512-YVbJZUtnzT5QsgJUp9H9uyJTW6NJgswFqI27RI/+MSox860uIjaGMbSQBftEzbMXiJVRG24hpoIh3SG666SHgA==",
+          "dev": true
+        },
+        "min-dom": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.1.3.tgz",
+          "integrity": "sha512-Lbi1NZjLV9Hg6/bEe2Lfk2Fzsv1MwheR61whqTLP+FxLndYo9TxpksEgM5Kr1khjfCtFTMr0waeEfwIpStkRdw==",
+          "dev": true,
+          "requires": {
+            "component-event": "^0.1.4",
+            "domify": "^1.3.1",
+            "indexof": "0.0.1",
+            "matches-selector": "^1.2.0"
+          }
+        }
       }
     },
     "didi": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-env": "^1.6.1",
     "babelify": "^8.0.0",
     "bpmn-font": "^0.8.0",
-    "bpmn-js": "^7.5.0",
+    "bpmn-js": "^8.2.0",
     "browserify": "^16.1.1",
     "chai": "^4.1.2",
     "diagram-js": "^6.0.1",
@@ -47,7 +47,7 @@
     "watchify": "^3.9.0"
   },
   "peerDependencies": {
-    "bpmn-js": "^1.3.x || ^2.x || ^3.x || ^4.x || ^5.x || ^6.x || ^7.x"
+    "bpmn-js": "^1.3.x || ^2.x || ^3.x || ^4.x || ^5.x || ^6.x || ^7.x || ^8.x"
   },
   "dependencies": {
     "min-dash": "^3.2.0"


### PR DESCRIPTION
Increase peer-dependency to bpmn-js@8 to avoid warnings via install.

Related to https://github.com/camunda/camunda-bpmn-js/issues/1